### PR TITLE
11 - 言語切り替えボタンを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+**.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 **.DS_Store
+dev_bundle

--- a/.meteor/dev_bundle
+++ b/.meteor/dev_bundle
@@ -1,1 +1,0 @@
-/Users/yuri/.meteor/packages/meteor-tool/.1.3.4_4.4e21ac++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle

--- a/.meteor/dev_bundle
+++ b/.meteor/dev_bundle
@@ -1,0 +1,1 @@
+/Users/yuri/.meteor/packages/meteor-tool/.1.3.4_4.4e21ac++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -21,3 +21,4 @@ shell-server@0.2.1            # Server-side component of the `meteor shell` comm
 kadira:flow-router
 ultimatejs:tracker-react
 universe:i18n
+twbs:bootstrap

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -65,6 +65,7 @@ templating-compiler@1.2.15
 templating-runtime@1.2.15
 templating-tools@1.0.5
 tracker@1.1.0
+twbs:bootstrap@3.3.6
 ui@1.0.12
 ultimatejs:tracker-react@1.0.5
 underscore@1.0.9

--- a/imports/startup/client/routes.jsx
+++ b/imports/startup/client/routes.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LanguageSelector from '../../ui/components/LanguageSelector.jsx';
 import { mount } from 'react-mounter';
 import { MainPage } from '../../ui/pages/MainPage.jsx';
 
@@ -7,7 +6,7 @@ FlowRouter.route('/', {
   action() {
     Tracker.autorun(function() {
       mount(MainPage, {
-        content: (<LanguageSelector />),
+        content: (<MainPage />),
       });
     });
   },

--- a/imports/startup/client/routes.jsx
+++ b/imports/startup/client/routes.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import LanguageSelector from '../../ui/components/LanguageSelector.jsx';
 import { mount } from 'react-mounter';
 import { MainPage } from '../../ui/pages/MainPage.jsx';
 
@@ -6,8 +7,8 @@ FlowRouter.route('/', {
   action() {
     Tracker.autorun(function() {
       mount(MainPage, {
-
+        content: (<LanguageSelector />),
       });
     });
-  }
+  },
 });

--- a/imports/ui/components/LanguageSelector.jsx
+++ b/imports/ui/components/LanguageSelector.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import i18n from 'meteor/universe:i18n';
+import { DropdownButton, MenuItem } from 'react-bootstrap';
+
+export default class LanguageSelector extends React.Component {
+  setLocaleLanguage(eventKey) {
+    if ( eventKey === "ja" ) {
+      i18n.setLocale( "ja" );
+    } else {
+      i18n.setLocale( "en" );
+    }
+  }
+
+  getLanguage() {
+    const BUFFER_LANG = i18n.getLanguageName();
+    let lang = "";
+
+    if ( BUFFER_LANG === "Japanese"
+         || BUFFER_LANG === "JAPANESE"
+         || BUFFER_LANG === "ja"
+         || BUFFER_LANG === "Japanese (Japan)"
+         || BUFFER_LANG === "JA"
+         || BUFFER_LANG === "ja-JP" ) {
+      lang = "ja";
+    } else {
+      lang = "en";
+    }
+    return lang;
+  }
+
+  generateTitle() {
+    return (
+      <i className='glyphicon glyphicon-globe'> { this.getLanguage() }</i>
+    );
+  }
+
+  componentDidMount() {
+    this.setLocaleLanguage( this.getLanguage() );
+  }
+
+  render() {
+    return (
+      <div>
+        <DropdownButton bsStyle="primary" title={this.generateTitle()} noCaret id='dropdown-basic'>
+          <MenuItem eventKey=""  onClick={() => this.setLocaleLanguage("ja")}>ja</MenuItem>
+          <MenuItem eventKey=""  onClick={() => this.setLocaleLanguage("en")}>en</MenuItem>
+        </DropdownButton>
+      </div>
+    );
+  }
+}

--- a/imports/ui/components/LanguageSelector.jsx
+++ b/imports/ui/components/LanguageSelector.jsx
@@ -3,8 +3,8 @@ import i18n from 'meteor/universe:i18n';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 export default class LanguageSelector extends React.Component {
-  setLocaleLanguage(eventKey) {
-    if ( eventKey === "ja" ) {
+  setLocaleLanguage(language) {
+    if ( language === "ja" ) {
       i18n.setLocale( "ja" );
     } else {
       i18n.setLocale( "en" );
@@ -12,15 +12,15 @@ export default class LanguageSelector extends React.Component {
   }
 
   getLanguage() {
-    const BUFFER_LANG = i18n.getLanguageName();
+    const bufferLang = i18n.getLanguageName();
     let lang = "";
 
-    if ( BUFFER_LANG === "Japanese"
-         || BUFFER_LANG === "JAPANESE"
-         || BUFFER_LANG === "ja"
-         || BUFFER_LANG === "Japanese (Japan)"
-         || BUFFER_LANG === "JA"
-         || BUFFER_LANG === "ja-JP" ) {
+    if ( bufferLang === "Japanese"
+         || bufferLang === "JAPANESE"
+         || bufferLang === "ja"
+         || bufferLang === "Japanese (Japan)"
+         || bufferLang === "JA"
+         || bufferLang === "ja-JP" ) {
       lang = "ja";
     } else {
       lang = "en";
@@ -42,8 +42,8 @@ export default class LanguageSelector extends React.Component {
     return (
       <div>
         <DropdownButton bsStyle="primary" title={this.generateTitle()} noCaret id='dropdown-basic'>
-          <MenuItem eventKey=""  onClick={() => this.setLocaleLanguage("ja")}>ja</MenuItem>
-          <MenuItem eventKey=""  onClick={() => this.setLocaleLanguage("en")}>en</MenuItem>
+          <MenuItem onClick={() => this.setLocaleLanguage("ja")}>ja</MenuItem>
+          <MenuItem onClick={() => this.setLocaleLanguage("en")}>en</MenuItem>
         </DropdownButton>
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
     "start": "meteor run"
   },
   "dependencies": {
+    "bootstrap": "^3.3.7",
     "meteor-node-stubs": "~0.2.0",
     "react": "^15.3.2",
+    "react-bootstrap": "^0.30.5",
     "react-dom": "^15.3.2",
     "react-mounter": "^1.2.0"
   },


### PR DESCRIPTION
## 説明

react-bootstrapを追加しました
i18nを用いて言語を切り替えれるようにした
getLanguage()を作り、ブラウザーによって言語が違うことがあるのできれいにできるようにした
## テストのやり方

Slackのscriptに貼ったTest.jsxをLanguageSelector.jsxと同じディレクトリに入れ、router.jsxをいじったらリアクティブになるのでリアクティブのテストをしていただきたいです
## 備考

言語の初期値がただしいかチェックしてほしいです。
## Issue

[言語切り替えボタンを追加する](https://github.com/OIC-Odin/smart-remote/issues/11)
