### PR TITLE
31 - テストフレームワークを導入する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
-run/
+run/settings.json
 **.DS_Store
 dev_bundle

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -25,3 +25,5 @@ email@1.1.17_1
 meteorhacks:ssr
 accounts-password@1.3.0
 twbs:bootstrap
+practicalmeteor:mocha
+xolvio:cleaner

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -14,6 +14,7 @@ caching-compiler@1.1.7_1
 caching-html-compiler@1.0.7
 callback-hook@1.0.9
 check@1.2.3
+coffeescript@1.0.17
 ddp@1.2.5
 ddp-client@1.2.9
 ddp-common@1.2.6
@@ -55,6 +56,11 @@ npm-bcrypt@0.9.1_1
 npm-mongo@2.2.11_1
 observe-sequence@1.0.12
 ordered-dict@1.0.8
+practicalmeteor:chai@2.1.0_1
+practicalmeteor:loglevel@1.2.0_2
+practicalmeteor:mocha@2.4.5_6
+practicalmeteor:mocha-core@1.0.1
+practicalmeteor:sinon@1.14.1_2
 promise@0.8.7
 random@1.0.10
 rate-limit@1.0.5
@@ -75,6 +81,7 @@ templating@1.2.15
 templating-compiler@1.2.15
 templating-runtime@1.2.15
 templating-tools@1.0.5
+tmeasday:test-reporter-helpers@0.2.1
 tracker@1.1.0
 twbs:bootstrap@3.3.6
 ui@1.0.12
@@ -85,3 +92,4 @@ universe:utilities@2.3.3
 url@1.0.10
 webapp@1.3.11_1
 webapp-hashing@1.0.9
+xolvio:cleaner@0.3.1

--- a/end_to_end_tests/features/language_selection.feature
+++ b/end_to_end_tests/features/language_selection.feature
@@ -1,0 +1,13 @@
+Feature: 言語を設定する
+  ユーザーとして
+  自分で言語を設定することができるはず
+
+  Scenario: 言語を日本語に設定する
+    Given I am at register page
+    When I use the language selector to switch language to Japanese
+    Then the application language should be set to Japanese
+
+  Scenario: 言語を英語に設定する
+    Given I am at register page
+    When I use the language selector to switch language to English
+    Then the application language should be set to English

--- a/end_to_end_tests/features/support/language_selection.js
+++ b/end_to_end_tests/features/support/language_selection.js
@@ -1,0 +1,26 @@
+module.exports = function() {
+
+  this.Given(/^I am at register page$/, function() {
+    browser.url('http://localhost:3000/register');
+  });
+
+  this.When(/^I use the language selector to switch language to Japanese$/, function() {
+    browser.waitForExist("#language-selector");
+    browser.click("#language-selector");
+    browser.click("#lang-ja");
+  });
+
+  this.Then(/^the application language should be set to Japanese$/, function() {
+    expect(browser.getText("#language-selector")).toEqual("ja");
+  });
+
+  this.When(/^I use the language selector to switch language to English$/, function() {
+    browser.waitForExist("#language-selector");
+    browser.click("#language-selector");
+    browser.click("#lang-en");
+  });
+
+  this.Then(/^the application language should be set to English$/, function() {
+    expect(browser.getText("#language-selector")).toEqual("en");
+  });
+};

--- a/imports/api/emails/server/methods.tests.js
+++ b/imports/api/emails/server/methods.tests.js
@@ -1,0 +1,43 @@
+import './methods.js';
+import { chai } from 'meteor/practicalmeteor:chai';
+import i18n from 'meteor/universe:i18n';
+import { resetDatabase } from 'meteor/xolvio:cleaner';
+import faker from 'faker';
+
+describe('メール', function() {
+  beforeEach( function() {
+    resetDatabase();
+  });
+
+  it('英語でメールを送信できる', function() {
+    Meteor.call('sendEnrollmentEmail', 'en', faker.internet.email());
+    chai.assert.equal(i18n.getLocale(), 'en');
+  });
+
+  it('日本語でメールを送信できる', function() {
+    Meteor.call('sendEnrollmentEmail', 'ja', faker.internet.email());
+    chai.assert.equal(i18n.getLocale(), 'ja');
+  });
+
+  it('対応してない言語のであれば、英語でメールが送信される', function() {
+    Meteor.call('sendEnrollmentEmail', 'lv', faker.internet.email());
+    chai.assert.equal(i18n.getLocale(), 'en');
+  });
+
+  it('無効なメールアドレス入力されたら、エラーがでる', function() {
+    try {
+      Meteor.call('sendEnrollmentEmail', 'en', 'invalid email address');
+    } catch (Error) {
+      chai.expect(Error.error).to.equal('Invalid parameters.');
+    }
+  });
+  it('同じメールアドレスでもう一回登録しようとした、エラーがでる', function() {
+    try {
+      const email = faker.internet.email();
+      Meteor.call('sendEnrollmentEmail', 'en', email);
+      Meteor.call('sendEnrollmentEmail', 'en', email);
+    } catch (Error) {
+      chai.expect(Error.reason).to.equal('Email already exists.');
+    }
+  });
+});

--- a/imports/ui/components/LanguageSelector.jsx
+++ b/imports/ui/components/LanguageSelector.jsx
@@ -41,9 +41,9 @@ export default class LanguageSelector extends React.Component {
   render() {
     return (
       <div>
-        <DropdownButton bsStyle="primary" title={this.generateTitle()} noCaret id='dropdown-basic'>
-          <MenuItem onClick={() => this.setLocaleLanguage("ja")}>ja</MenuItem>
-          <MenuItem onClick={() => this.setLocaleLanguage("en")}>en</MenuItem>
+        <DropdownButton bsStyle="primary" title={this.generateTitle()} noCaret id='language-selector'>
+          <MenuItem id="lang-ja" onClick={() => this.setLocaleLanguage("ja")}>ja</MenuItem>
+          <MenuItem id="lang-en" onClick={() => this.setLocaleLanguage("en")}>en</MenuItem>
         </DropdownButton>
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "eslint": "^3.7.1",
     "eslint-import-resolver-meteor": "^0.3.3",
     "eslint-plugin-import": "^2.0.0",
-    "eslint-plugin-react": "^6.4.0"
+    "eslint-plugin-react": "^6.4.0",
+    "gulp-chimp": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "dependencies": {
     "bcrypt": "^0.8.7",
     "bootstrap": "^3.3.7",
+    "faker": "^3.1.0",
+    "isemail": "^2.2.1",
     "meteor-node-stubs": "~0.2.0",
     "react": "^15.3.2",
     "react-bootstrap": "^0.30.5",

--- a/run/development
+++ b/run/development
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+meteor --settings ./run/settings.json

--- a/run/end_to_end_tests
+++ b/run/end_to_end_tests
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chimp --path ./end_to_end_tests

--- a/run/end_to_end_tests_watch
+++ b/run/end_to_end_tests_watch
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chimp --watch --path ./end_to_end_tests

--- a/run/unit_tests
+++ b/run/unit_tests
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+meteor test --driver-package practicalmeteor:mocha --port 3100 --settings ./run/settings.json


### PR DESCRIPTION
## 説明
単体テストのために：Mocha.js, Chai.js を追加。
End to endテストのために：Cucumber.js, Chimp.js を追加
言語選択ボタンの end to end テスト追加。
sendEnrollmentEmailの単体テスト追加。
アプリ、テスト起動用スクリプト追加

## 備考
今からアプリ開発ために起動するにはルートディレクトリから
`./run/develop`
単体テスト起動
`./run/unit_tests`
end to endテスト(普通)起動
`./run/end_to_end_tests`
end to endテスト(ウォッチモード)
`./run/end_to_end_tests_watch`
を使ったらいい。

## Issue

[テストフレームワークを導入する](https://github.com/OIC-Odin/smart-remote/issues/31)
