### PR TITLE
28 - ログイン・登録ページのデザイン

### DIFF
--- a/client/main.css
+++ b/client/main.css
@@ -1,0 +1,100 @@
+/* common style */
+
+body {
+  background-color: #1C2936;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN","メイリオ", sans-serif;
+  font-weight: 100;
+}
+
+.center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.button-style {
+  border-style: none;
+  border: 1px solid #18A3BC;
+  border-radius: 10px;
+  padding: 15px 40px;
+  width: 250px;
+  color: #fff;
+  font-size: 16px;
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.button-style:disabled {
+  border-color: #5C5C5C;
+}
+
+.input-style {
+  border-style: none;
+  border-bottom: 1px solid #fff;
+  color: #fff;
+  font-size: 15px;
+  width: 250px;
+  padding: 5px;
+  margin-top: 36px;
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.positon {
+  position: relative;
+}
+
+/* Sign in Page */
+
+.sign-in-center {
+  margin-top: 90px;
+}
+
+.forgot-password {
+  display: flex;
+  flex-direction: row-reverse;
+  font-size: 12px;
+  color: #18A3BC;
+  margin: 5px 0 30px 0;
+}
+
+.sign-in-box {
+  width: 250px;
+  margin: 24px 0 0 0;
+}
+
+.sign-in-box .sign-in-message {
+  color: #fff;
+  margin-right: 15px;
+}
+
+.sign-in-box .sign-in-link {
+  color: #18A3BC;
+}
+
+/* Register Page */
+
+.register-center {
+  margin-top: 105px;
+}
+
+.register-button {
+  margin: 200px 0 30px 0;
+}
+
+/* Enroll Account Page */
+
+.enroll-center {
+  padding-top: 65px;
+}
+
+.country-drop-down select {
+  width: 250px;
+  background-color: rgba(0, 0, 0, 0);
+  border-style: none;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.enroll-button {
+  margin: 120px 0 30px 0;
+}

--- a/client/main.html
+++ b/client/main.html
@@ -1,7 +1,6 @@
 <head>
   <title>Smart Remote</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="main.css">
 </head>
 
 <body>

--- a/client/main.html
+++ b/client/main.html
@@ -1,6 +1,7 @@
 <head>
   <title>Smart Remote</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="main.css">
 </head>
 
 <body>

--- a/imports/api/validator/form_validator.js
+++ b/imports/api/validator/form_validator.js
@@ -8,7 +8,9 @@ let style = {
     color: "red",
     fontSize: "12px",
     marginTop: 3,
-  },
+    width: "250px",
+    position: "absolute"
+  }
 };
 
 Object.assign(Validation.rules, {

--- a/imports/ui/components/CountrySelector.jsx
+++ b/imports/ui/components/CountrySelector.jsx
@@ -18,19 +18,35 @@ export default class CountrySelector extends React.Component {
 
   render() {
     const { country, region } = this.state;
+    let style = {
+      selector: {
+        color: "#fff",
+        border: "none",
+        borderRadius: "initial",
+        borderBottom: "1px solid #fff",
+        backgroundColor: "rgba(0, 0, 0, 0)",
+        padding: "5px",
+        marginTop: "36px",
+        width: "250px"
+      }
+    };
     return (
-      <div>
-      <CountryDropdown
-      value={country}
-      name="country"
-      valueType="short"
-      onChange={(val) => this.selectCountry(val)} />
-      <RegionDropdown
-      value={region}
-      name="city"
-      countryValueType="short"
-      country={country}
-      onChange={(val) => this.selectRegion(val)} />
+      <div className="country-drop-down">
+      <div style={style.selector}>
+        <CountryDropdown
+          value={country}
+          name="country"
+          valueType="short"
+          onChange={(val) => this.selectCountry(val)} />
+      </div>
+      <div style={style.selector}>
+        <RegionDropdown
+          value={region}
+          name="city"
+          countryValueType="short"
+          country={country}
+          onChange={(val) => this.selectRegion(val)} />
+      </div>
       </div>
     );
   }

--- a/imports/ui/components/Header.jsx
+++ b/imports/ui/components/Header.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import LanguageSelector from './LanguageSelector';
+import { Grid, Col, Row } from 'react-bootstrap';
+
+export default class Header extends React.Component {
+
+  render() {
+    let style = {
+      header: {
+        display: "flex",
+        alignItems: "center",
+        margin: "20px 0"
+      },
+      h1: {
+        margin: 0,
+        fontSize: "18px",
+        color: "#fff",
+        textAlign: "center"
+      }
+    };
+
+    return (
+      <Grid>
+        <Row style={style.header}>
+          <Col xs={2} md={3} >
+            {/* TODO  */}
+          </Col>
+          <Col xs={9} md={6}>
+            <h1 style={style.h1}>Smart Controller</h1>
+          </Col>
+          <Col xs={2} md={3}>
+            <LanguageSelector/>
+          </Col>
+        </Row>
+      </Grid>
+    );
+  }
+}

--- a/imports/ui/components/LanguageSelector.jsx
+++ b/imports/ui/components/LanguageSelector.jsx
@@ -29,8 +29,19 @@ export default class LanguageSelector extends React.Component {
   }
 
   generateTitle() {
+    let style = {
+      languageStyle: {
+        color: "#fff",
+      },
+      iconStyle: {
+        marginRight: "3px",
+      }
+    };
     return (
-      <i className='glyphicon glyphicon-globe'> { this.getLanguage() }</i>
+      <div style={style.languageStyle}>
+        <i className='glyphicon glyphicon-globe' style={style.iconStyle}/>
+        { this.getLanguage() }
+      </div>
     );
   }
 
@@ -39,9 +50,20 @@ export default class LanguageSelector extends React.Component {
   }
 
   render() {
+    let style = {
+      buttonStyle: {
+        backgroundColor: "rgba(0, 0, 0, 0)",
+        borderStyle: "none"
+      }
+    }
     return (
       <div>
-        <DropdownButton bsStyle="primary" title={this.generateTitle()} noCaret id='language-selector'>
+        <DropdownButton
+          title={this.generateTitle()}
+          noCaret
+          id='language-selector'
+          style={style.buttonStyle}
+          >
           <MenuItem id="lang-ja" onClick={() => this.setLocaleLanguage("ja")}>ja</MenuItem>
           <MenuItem id="lang-en" onClick={() => this.setLocaleLanguage("en")}>en</MenuItem>
         </DropdownButton>

--- a/imports/ui/layouts/EnrollAccount.jsx
+++ b/imports/ui/layouts/EnrollAccount.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import i18n from 'meteor/universe:i18n';
-import LanguageSelector from '../components/LanguageSelector';
+import Header from '../components/Header';
 import Validation from 'react-validation';
 import '../../api/validator/form_validator';
 import CountrySelector from '../components/CountrySelector';
+import { Grid, Col, Row } from 'react-bootstrap';
 
 export default class EnrollAccount extends React.Component {
   constructor() {
@@ -46,26 +47,33 @@ export default class EnrollAccount extends React.Component {
   render() {
     return (
       <div>
-      <LanguageSelector/>
+      <Header/>
+      <div className="center enroll-center">
       <Validation.components.Form onSubmit={this.handleSubmit.bind(this)}>
-        <h3>Registration</h3>
+        <div className="position">
         <Validation.components.Input
           id='input-password'
+          className='input-style'
           type='password'
           value=''
           name='password'
           placeholder={i18n.getTranslation('form', 'password')}
           validations={['required', 'password']}/>
+        </div>
+        <div className="position">
         <Validation.components.Input
           id='input-confirm-password'
+          className='input-style'
           type='password'
           value=''
           name='confirmPassword'
           placeholder={i18n.getTranslation('form', 'confirmPassword')}
           validations={['required', 'confirmPassword']}/>
+        </div>
         <CountrySelector/>
-        <Validation.components.Button>{i18n.getTranslation('form', 'enrollBtn')}</Validation.components.Button>
+        <Validation.components.Button className="button-style enroll-button">{i18n.getTranslation('form', 'enrollBtn')}</Validation.components.Button>
       </Validation.components.Form>
+      </div>
       </div>
     );
   }

--- a/imports/ui/layouts/EnrollAccount.jsx
+++ b/imports/ui/layouts/EnrollAccount.jsx
@@ -47,33 +47,33 @@ export default class EnrollAccount extends React.Component {
   render() {
     return (
       <div>
-      <Header/>
-      <div className="center enroll-center">
-      <Validation.components.Form onSubmit={this.handleSubmit.bind(this)}>
-        <div className="position">
-        <Validation.components.Input
-          id='input-password'
-          className='input-style'
-          type='password'
-          value=''
-          name='password'
-          placeholder={i18n.getTranslation('form', 'password')}
-          validations={['required', 'password']}/>
+        <Header/>
+        <div className="center enroll-center">
+          <Validation.components.Form onSubmit={this.handleSubmit.bind(this)}>
+            <div className="position">
+              <Validation.components.Input
+                id='input-password'
+                className='input-style'
+                type='password'
+                value=''
+                name='password'
+                placeholder={i18n.getTranslation('form', 'password')}
+                validations={['required', 'password']}/>
+            </div>
+            <div className="position">
+              <Validation.components.Input
+                id='input-confirm-password'
+                className='input-style'
+                type='password'
+                value=''
+                name='confirmPassword'
+                placeholder={i18n.getTranslation('form', 'confirmPassword')}
+                validations={['required', 'confirmPassword']}/>
+            </div>
+            <CountrySelector/>
+            <Validation.components.Button className="button-style enroll-button">{i18n.getTranslation('form', 'enrollBtn')}</Validation.components.Button>
+          </Validation.components.Form>
         </div>
-        <div className="position">
-        <Validation.components.Input
-          id='input-confirm-password'
-          className='input-style'
-          type='password'
-          value=''
-          name='confirmPassword'
-          placeholder={i18n.getTranslation('form', 'confirmPassword')}
-          validations={['required', 'confirmPassword']}/>
-        </div>
-        <CountrySelector/>
-        <Validation.components.Button className="button-style enroll-button">{i18n.getTranslation('form', 'enrollBtn')}</Validation.components.Button>
-      </Validation.components.Form>
-      </div>
       </div>
     );
   }

--- a/imports/ui/layouts/EnrollAccount.jsx
+++ b/imports/ui/layouts/EnrollAccount.jsx
@@ -4,7 +4,6 @@ import Header from '../components/Header';
 import Validation from 'react-validation';
 import '../../api/validator/form_validator';
 import CountrySelector from '../components/CountrySelector';
-import { Grid, Col, Row } from 'react-bootstrap';
 
 export default class EnrollAccount extends React.Component {
   constructor() {

--- a/imports/ui/layouts/Register.jsx
+++ b/imports/ui/layouts/Register.jsx
@@ -46,38 +46,26 @@ export default class Register extends React.Component {
         <Header/>
         <Grid className="center register-center">
           <Validation.components.Form onSubmit={this.handleSubmit.bind(this)}>
-            <Row>
-              <Col>
-                <Validation.components.Input
-                  id="input-email"
-                  type="email"
-                  value=''
-                  name="registerEmail"
-                  placeholder={i18n.getTranslation('form', 'email')}
-                  validations={['required', 'email']}
-                  className="input-style"/>
-              </Col>
-            </Row>
-            <Row>
-              <Col>
-                <Validation.components.Input
-                  id="input-confirm-email"
-                  type="email"
-                  value=''
-                  name="confirmEmail"
-                  placeholder={i18n.getTranslation('form', 'confirmEmail')}
-                  validations={['confirmEmail']}
-                  className="input-style"/>
-                </Col>
-            </Row>
-            <Row>
-              <Col>
-                <Validation.components.Button
-                  className="button-style register-button">
-                  {i18n.getTranslation('form', 'registerBtn')}
-                </Validation.components.Button>
-              </Col>
-            </Row>
+            <Validation.components.Input
+              id="input-email"
+              type="email"
+              value=''
+              name="registerEmail"
+              placeholder={i18n.getTranslation('form', 'email')}
+              validations={['required', 'email']}
+              className="input-style"/>
+            <Validation.components.Input
+              id="input-confirm-email"
+              type="email"
+              value=''
+              name="confirmEmail"
+              placeholder={i18n.getTranslation('form', 'confirmEmail')}
+              validations={['confirmEmail']}
+              className="input-style"/>
+            <Validation.components.Button
+              className="button-style register-button">
+              {i18n.getTranslation('form', 'registerBtn')}
+            </Validation.components.Button>
           </Validation.components.Form>
         </Grid>
       </div>

--- a/imports/ui/layouts/Register.jsx
+++ b/imports/ui/layouts/Register.jsx
@@ -4,7 +4,7 @@ import i18n from 'meteor/universe:i18n';
 import Header from '../components/Header';
 import Validation from 'react-validation';
 import '../../api/validator/form_validator';
-import { Grid, Col, Row } from 'react-bootstrap';
+import { Grid } from 'react-bootstrap';
 
 export default class Register extends React.Component {
   constructor() {

--- a/imports/ui/layouts/Register.jsx
+++ b/imports/ui/layouts/Register.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Meteor } from 'meteor/meteor';
 import i18n from 'meteor/universe:i18n';
-import LanguageSelector from '../components/LanguageSelector';
+import Header from '../components/Header';
 import Validation from 'react-validation';
 import '../../api/validator/form_validator';
+import { Grid, Col, Row } from 'react-bootstrap';
 
 export default class Register extends React.Component {
   constructor() {
@@ -42,24 +43,43 @@ export default class Register extends React.Component {
   render() {
     return (
       <div>
-        <LanguageSelector/>
-        <Validation.components.Form onSubmit={this.handleSubmit.bind(this)}>
-          <Validation.components.Input
-            id="input-email"
-            type="email"
-            value=''
-            name="registerEmail"
-            placeholder={i18n.getTranslation('form', 'email')}
-            validations={['required', 'email']}/>
-          <Validation.components.Input
-            id="input-confirm-email"
-            type="email"
-            value=''
-            name="confirmEmail"
-            placeholder={i18n.getTranslation('form', 'confirmEmail')}
-            validations={['confirmEmail']}/>
-          <Validation.components.Button>{i18n.getTranslation('form', 'registerBtn')}</Validation.components.Button>
-        </Validation.components.Form>
+        <Header/>
+        <Grid className="center register-center">
+          <Validation.components.Form onSubmit={this.handleSubmit.bind(this)}>
+            <Row>
+              <Col>
+                <Validation.components.Input
+                  id="input-email"
+                  type="email"
+                  value=''
+                  name="registerEmail"
+                  placeholder={i18n.getTranslation('form', 'email')}
+                  validations={['required', 'email']}
+                  className="input-style"/>
+              </Col>
+            </Row>
+            <Row>
+              <Col>
+                <Validation.components.Input
+                  id="input-confirm-email"
+                  type="email"
+                  value=''
+                  name="confirmEmail"
+                  placeholder={i18n.getTranslation('form', 'confirmEmail')}
+                  validations={['confirmEmail']}
+                  className="input-style"/>
+                </Col>
+            </Row>
+            <Row>
+              <Col>
+                <Validation.components.Button
+                  className="button-style register-button">
+                  {i18n.getTranslation('form', 'registerBtn')}
+                </Validation.components.Button>
+              </Col>
+            </Row>
+          </Validation.components.Form>
+        </Grid>
       </div>
     );
   }

--- a/imports/ui/layouts/SignIn.jsx
+++ b/imports/ui/layouts/SignIn.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {Meteor} from 'meteor/meteor';
 import i18n from 'meteor/universe:i18n';
-import LanguageSelector from '../components/LanguageSelector';
+import Header from '../components/Header';
+import { Grid, Col, Row } from 'react-bootstrap';
 
 export default class SignIn extends React.Component {
   constructor() {
@@ -41,15 +42,39 @@ export default class SignIn extends React.Component {
   render() {
     return (
       <div>
-      <LanguageSelector/>
+      <Header/>
+      <Grid className="center sign-in-center">
       <form onSubmit = {this.handleSubmit.bind(this)}>
-        <input type="email" name="email" placeholder={i18n.getTranslation('form', 'email')} />
-        <input type="password" name="password" placeholder={i18n.getTranslation('form', 'password')} />
-        <a href="reset-password">{i18n.getTranslation('signIn', 'forgotPassword')}</a>
-        <button type="submit">{i18n.getTranslation('form', 'signIn')}</button>
+        <Row>
+        <Col>
+        <input
+          type="email"
+          name="email"
+          placeholder={i18n.getTranslation('form', 'email')}
+          className="input-style"/>
+        </Col>
+        </Row>
+        <Row>
+        <Col>
+        <input
+          type="password"
+          name="password"
+          placeholder={i18n.getTranslation('form', 'password')}
+          className="input-style"/>
+        </Col>
+        </Row>
+        <Row>
+        <a href="reset-password" className="forgot-password">{i18n.getTranslation('signIn', 'forgotPassword')}</a>
+        </Row>
+        <Row>
+        <button type="submit" className="button-style">{i18n.getTranslation('form', 'signIn')}</button>
+        </Row>
       </form>
-      <span>{i18n.getTranslation('signIn', 'needAccount')}</span>
-      <a href="register">{i18n.getTranslation('signIn', 'signUp')}</a>
+      <div className="sign-in-box">
+        <span className="sign-in-message">{i18n.getTranslation('signIn', 'needAccount')}</span>
+        <a href="register" className="sign-in-link sign-in-button">{i18n.getTranslation('signIn', 'signUp')}</a>
+      </div>
+      </Grid>
       </div>
     );
   }

--- a/imports/ui/layouts/SignIn.jsx
+++ b/imports/ui/layouts/SignIn.jsx
@@ -42,39 +42,39 @@ export default class SignIn extends React.Component {
   render() {
     return (
       <div>
-      <Header/>
-      <Grid className="center sign-in-center">
-      <form onSubmit = {this.handleSubmit.bind(this)}>
-        <Row>
-        <Col>
-        <input
-          type="email"
-          name="email"
-          placeholder={i18n.getTranslation('form', 'email')}
-          className="input-style"/>
-        </Col>
-        </Row>
-        <Row>
-        <Col>
-        <input
-          type="password"
-          name="password"
-          placeholder={i18n.getTranslation('form', 'password')}
-          className="input-style"/>
-        </Col>
-        </Row>
-        <Row>
-        <a href="reset-password" className="forgot-password">{i18n.getTranslation('signIn', 'forgotPassword')}</a>
-        </Row>
-        <Row>
-        <button type="submit" className="button-style">{i18n.getTranslation('form', 'signIn')}</button>
-        </Row>
-      </form>
-      <div className="sign-in-box">
-        <span className="sign-in-message">{i18n.getTranslation('signIn', 'needAccount')}</span>
-        <a href="register" className="sign-in-link sign-in-button">{i18n.getTranslation('signIn', 'signUp')}</a>
-      </div>
-      </Grid>
+        <Header/>
+        <Grid className="center sign-in-center">
+        <form onSubmit = {this.handleSubmit.bind(this)}>
+          <Row>
+            <Col>
+              <input
+                type="email"
+                name="email"
+                placeholder={i18n.getTranslation('form', 'email')}
+                className="input-style"/>
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              <input
+                type="password"
+                name="password"
+                placeholder={i18n.getTranslation('form', 'password')}
+                className="input-style"/>
+            </Col>
+          </Row>
+          <Row>
+            <a href="reset-password" className="forgot-password">{i18n.getTranslation('signIn', 'forgotPassword')}</a>
+          </Row>
+          <Row>
+            <button type="submit" className="button-style">{i18n.getTranslation('form', 'signIn')}</button>
+          </Row>
+        </form>
+        <div className="sign-in-box">
+          <span className="sign-in-message">{i18n.getTranslation('signIn', 'needAccount')}</span>
+          <a href="register" className="sign-in-link sign-in-button">{i18n.getTranslation('signIn', 'signUp')}</a>
+        </div>
+        </Grid>
       </div>
     );
   }


### PR DESCRIPTION
# 説明
LanguageSelectorコンポーネントをHeaderコンポーネントの中に格納
sign-inページのスマホ用スタイルを作成
registerページのスマホ用スタイルを作成
enroll-accountページのスマホ用スタイルを作成
layouts以下のファイルのスタイルをまとめるためのcssを追加

# 備考
れいあうとつかれた

# Issue
[ログイン・登録ページのデザイン](https://github.com/OIC-Odin/smart-remote/issues/28)