### PR TITLE
83 - input要素をフォーカズ時にレイアウトが崩れる現象の修正

### DIFF
--- a/client/main.css
+++ b/client/main.css
@@ -46,7 +46,7 @@ body {
   border-bottom: 1px solid #fff;
   outline: 0;
   color: #fff;
-  font-size: 15px;
+  font-size: 16px;
   width: 250px;
   padding: 5px;
   margin-top: 36px;


### PR DESCRIPTION
## 説明
スマホでinput要素にフォーカスしたとき、フォントサイズが16px未満だと自動ズームされ、レイアウトが崩れる現象の修正

## issue
[スマホでinput要素にフォーカスしたとき、ズームされる現象の修正](https://github.com/OIC-Odin/smart-remote/issues/83)